### PR TITLE
Nie pokazuj daty na poczatku dzialania datepickera

### DIFF
--- a/src/components/datepicker.js
+++ b/src/components/datepicker.js
@@ -14,8 +14,8 @@ const datePicker = React.createClass({
 
   getInitialState: function() {
     return {
-      startDate: moment(),
-      endDate: moment()
+      startDate: null,
+      endDate: null
     };
   },
 


### PR DESCRIPTION
Wyzeruj daty datepicker, przy pierwszym wyswietleniu strony (gdy nie wybrano jeszcze zakresu daty), 